### PR TITLE
fixed a bug

### DIFF
--- a/classes/WebConsole/Channel.php
+++ b/classes/WebConsole/Channel.php
@@ -25,7 +25,7 @@ class Channel {
 	 * @param \WebConsole\Address $address The address and the port of the WebConsole server.
 	 */
 	public function __construct(Address $address) {
-		if (!defined(AF_INET)) {
+		if (AF_INET == "AF_INIT") {
 			// tell the user to enable the php_socket extension and end script execution
 			trigger_error("You need to enable the php_sockets extension!", E_USER_ERROR);
 		}


### PR DESCRIPTION
when php_sockets is not enabled, the value of AF_INET is "AF_INET" (which is defined but it is not the int value for the method).